### PR TITLE
Add a minimal Skills IL registry finder aligned with the official find-skills by Vercel skill pattern

### DIFF
--- a/find-skills-il/SKILL.md
+++ b/find-skills-il/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: find-skills-il
+description: >-
+  Find and compare Skills IL entries. Use when user asks to find a skill, search
+  the Skills IL registry, filter by category, agent, tag, creator, or page, or
+  inspect a skill before install. Do NOT use for general web search outside Skills IL.
+license: MIT
+allowed-tools: 'Bash(python:*) WebFetch'
+compatibility: >-
+  Requires network access to agentskills.co.il and a web fetch tool. Works with
+  Claude Code, Claude.ai, Cursor, OpenClaw, and other supported Skills IL agents.
+metadata:
+  author: TheCommandCat
+  version: 1.1.0
+  category: developer-tools
+  tags:
+    he:
+      - מאגר
+      - חיפוש
+      - גילוי
+      - סקילס-אי-אל
+    en:
+      - registry
+      - search
+      - discovery
+      - skills-il
+  display_name:
+    he: "מאתר סקילס IL"
+    en: Skills IL Finder
+  display_description:
+    he: "חיפוש, סינון ובדיקה מהירה של סקילים ב-Skills IL"
+    en: >-
+      Find and compare Skills IL entries. Use when user asks to find a skill,
+      search the Skills IL registry, filter by category, agent, tag, creator, or
+      page, or inspect a skill before install. Do NOT use for general web search
+      outside Skills IL.
+  supported_agents:
+    - claude-code
+    - cursor
+    - github-copilot
+    - windsurf
+    - opencode
+    - codex
+    - openclaw
+---
+
+# Skills IL Finder
+
+This skill helps you find, compare, and install skills from the Skills IL registry.
+
+## Instructions
+
+### Step 1: Understand the need
+Identify the topic, the target category, and whether the user wants discovery,
+comparison, or install help.
+
+### Step 2: Search the registry
+Start at `https://agentskills.co.il/en/skills` or `https://agentskills.co.il/he/skills`.
+Use `?q=` for search terms and `?page=N` to move through results.
+
+### Step 3: Filter and inspect
+Narrow by category, trust tier, agent, tag, creator, rating, or maintenance status.
+Open the skill page before recommending it and check the description, trust score,
+supported agents, install command, and whether `Download ZIP` is offered.
+
+### Step 4: Recommend or install
+If multiple skills fit, choose the one with the best match and trust score. If the
+user wants install help, copy the exact `npx skills-il add ...` command from the page
+or use `Download ZIP` for manual install.
+
+## Examples
+
+### Example 1: Find a skill
+User says: "Find a skill for Hebrew PDFs."
+Result: Search, filter, inspect top matches, and return the best one.
+
+### Example 2: Filter by agent
+User says: "Show developer tools skills with OpenClaw."
+Result: Filter by category and agent, then shortlist compatible skills.
+
+### Example 3: Install check
+User says: "Is this skill safe to install?"
+Result: Open the page, check trust score and install options, then answer briefly.
+
+## Troubleshooting
+
+### No results
+Broaden the query or switch category.
+
+### Wrong agent
+Recommend a different skill or say the agent is unsupported.

--- a/find-skills-il/SKILL_HE.md
+++ b/find-skills-il/SKILL_HE.md
@@ -1,0 +1,88 @@
+---
+name: find-skills-il
+description: >-
+  Find and compare Skills IL entries. Use when user asks to find a skill, search
+  the Skills IL registry, filter by category, agent, tag, creator, or page, or
+  inspect a skill before install. Do NOT use for general web search outside Skills IL.
+license: MIT
+allowed-tools: 'Bash(python:*) WebFetch'
+compatibility: >-
+  Requires network access to agentskills.co.il and a web fetch tool. Works with
+  Claude Code, Claude.ai, Cursor, OpenClaw, and other supported Skills IL agents.
+metadata:
+  author: TheCommandCat
+  version: 1.1.0
+  category: developer-tools
+  tags:
+    he:
+      - מאגר
+      - חיפוש
+      - גילוי
+      - סקילס-אי-אל
+    en:
+      - registry
+      - search
+      - discovery
+      - skills-il
+  display_name:
+    he: "מאתר סקילס IL"
+    en: Skills IL Finder
+  display_description:
+    he: "חיפוש, סינון ובדיקה מהירה של סקילים ב-Skills IL"
+    en: >-
+      Find and compare Skills IL entries. Use when user asks to find a skill,
+      search the Skills IL registry, filter by category, agent, tag, creator, or
+      page, or inspect a skill before install. Do NOT use for general web search
+      outside Skills IL.
+  supported_agents:
+    - claude-code
+    - cursor
+    - github-copilot
+    - windsurf
+    - opencode
+    - codex
+    - openclaw
+---
+
+# מאתר סקילס IL
+
+## הוראות
+
+### שלב 1: להבין את הצורך
+זהו את הנושא, הקטגוריה, והאם המשתמש רוצה גילוי, השוואה או עזרה בהתקנה.
+
+### שלב 2: לחפש ברישום
+התחילו ב־`https://agentskills.co.il/en/skills` או `https://agentskills.co.il/he/skills`.
+השתמשו ב־`?q=` למונחי חיפוש וב־`?page=N` למעבר בין תוצאות.
+
+### שלב 3: לסנן ולבדוק
+צמצמו לפי קטגוריה, רמת אמון, סוכן, תגית, יוצר, דירוג או מצב תחזוקה.
+פתחו את עמוד הסקיל לפני המלצה ובדקו תיאור, ציון אמון, סוכנים נתמכים,
+פקודת התקנה, והאם יש `Download ZIP`.
+
+### שלב 4: להמליץ או להתקין
+אם כמה סקילים מתאימים, בחרו את ההתאמה והאמון הטובים ביותר. אם המשתמש רוצה
+עזרה בהתקנה, העתיקו את פקודת `npx skills-il add ...` המדויקת מהעמוד או השתמשו
+ב־`Download ZIP` להתקנה ידנית.
+
+## דוגמאות
+
+### דוגמה 1: חיפוש סקיל
+המשתמש אומר: "Find a skill for Hebrew PDFs."
+תוצאה: חיפוש, סינון, בדיקת המועמדים המובילים והחזרת ההתאמה הטובה ביותר.
+
+### דוגמה 2: סינון לפי סוכן
+המשתמש אומר: "Show developer tools skills with OpenClaw."
+תוצאה: סינון לפי קטגוריה וסוכן, ואז רשימה קצרה של סקילים תואמים.
+
+### דוגמה 3: בדיקת התקנה
+המשתמש אומר: "Is this skill safe to install?"
+תוצאה: פתיחת העמוד, בדיקת ציון האמון ואפשרויות ההתקנה, ואז תשובה קצרה.
+
+## פתרון בעיות
+
+### אין תוצאות
+הרחיבו את החיפוש או החליפו קטגוריה.
+
+### הסוכן לא תואם
+המליצו על סקיל אחר או ציינו שהסוכן לא נתמך.


### PR DESCRIPTION
## Description
Adds `find-skills-il`, a minimal Skills IL registry finder that mirrors the official `find-skills` pattern while targeting the Skills IL directory. It supports searching, filtering, inspecting, and installing registry skills in a short, lightweight format.
## Checklist
> Structure, format, secrets, and word count are checked automatically by CI.
> The items below are things only YOU can verify.
### Quality (human review)
- [x] Description follows `[What] + [When] + [Capabilities]` pattern with trigger phrases
- [x] Instructions are specific and actionable (not vague)
- [x] Error handling / troubleshooting section included
- [x] Usage examples provided ("User says: ... → Result: ...")
- [x] No unauthorized external network calls
### Testing (required)
- [x] Tested triggering on obvious tasks (skill loads automatically)
- [x] Tested triggering on paraphrased requests
- [x] Verified doesn't trigger on unrelated topics
- [x] Tested on at least one AI agent (fill in table below)
## Agent Testing
| Agent | Tested? | Notes |
|-------|---------|-------|
| OpenCode | x | Loaded correctly |
| Claude Code |  | Not tested |
| Cursor |  | Not tested |